### PR TITLE
Change suit shift num

### DIFF
--- a/cards/card.go
+++ b/cards/card.go
@@ -2,6 +2,7 @@ package cards
 
 import (
 	"fmt"
+	"github.com/freecellsolver/consts"
 	"strconv"
 )
 
@@ -10,11 +11,11 @@ type Card struct {
 }
 
 func (card Card) GetSuitCode() uint8 {
-	return card.Code >> 5
+	return card.Code >> consts.SS
 }
 
 func (card Card) GetNumCode() uint8 {
-	return card.Code & 0x1f // 0x0f にする
+	return card.Code & 0x0f
 }
 
 func (card Card) IsBlack() bool {
@@ -37,7 +38,7 @@ func (card Card) ToReadableCard() (ReadableCard, error) {
 		return ReadableCard{}, fmt.Errorf("failed to convert suit: %d", suitCode)
 	}
 
-	numCode := card.Code - suitCode<<5
+	numCode := card.Code - suitCode<<consts.SS
 	num := ""
 	switch numCode {
 	case 1:

--- a/cards/card_test.go
+++ b/cards/card_test.go
@@ -26,17 +26,17 @@ func TestCard_GetSuitCode(t *testing.T) {
 		},
 		{
 			name:   "GetSuitCode 3",
-			fields: fields{uint8(33)}, // ♥A
+			fields: fields{uint8(17)}, // ♥A
 			want:   uint8(1),
 		},
 		{
 			name:   "GetSuitCode 4",
-			fields: fields{uint8(74)}, // ♣10
+			fields: fields{uint8(42)}, // ♣10
 			want:   uint8(2),
 		},
 		{
 			name:   "GetSuitCode 5",
-			fields: fields{uint8(109)}, // ♦K
+			fields: fields{uint8(61)}, // ♦K
 			want:   uint8(3),
 		},
 	}
@@ -68,17 +68,17 @@ func TestCard_IsBlack(t *testing.T) {
 		},
 		{
 			name:   "IsBlack Heart",
-			fields: fields{uint8(33)}, // ♥A
+			fields: fields{uint8(17)}, // ♥A
 			want:   false,
 		},
 		{
 			name:   "IsBlack Diamonds",
-			fields: fields{uint8(74)}, // ♣10
+			fields: fields{uint8(42)}, // ♣10
 			want:   true,
 		},
 		{
 			name:   "IsBlack Clover",
-			fields: fields{uint8(109)}, // ♦K
+			fields: fields{uint8(61)}, // ♦K
 			want:   false,
 		},
 	}
@@ -116,17 +116,17 @@ func TestCard_ToReadableCard(t *testing.T) {
 		},
 		{
 			name:   "ToReadableCard 3",
-			fields: fields{uint8(33)}, // ♥A
+			fields: fields{uint8(17)}, // ♥A
 			want:   ReadableCard{"♥", "A"},
 		},
 		{
 			name:   "ToReadableCard 4",
-			fields: fields{uint8(74)}, // ♣10
+			fields: fields{uint8(42)}, // ♣10
 			want:   ReadableCard{"♣", "10"},
 		},
 		{
 			name:   "ToReadableCard 5",
-			fields: fields{uint8(109)}, // ♦K
+			fields: fields{uint8(61)}, // ♦K
 			want:   ReadableCard{"♦", "K"},
 		},
 	}
@@ -223,17 +223,17 @@ func TestCard_GetNumCode(t *testing.T) {
 		},
 		{
 			name:   "GetNumCode 3",
-			fields: fields{uint8(33)}, // ♥A
+			fields: fields{uint8(17)}, // ♥A
 			want:   uint8(1),
 		},
 		{
 			name:   "GetNumCode 4",
-			fields: fields{uint8(74)}, // ♣10
+			fields: fields{uint8(42)}, // ♣10
 			want:   uint8(10),
 		},
 		{
 			name:   "GetNumCode 5",
-			fields: fields{uint8(109)}, // ♦K
+			fields: fields{uint8(61)}, // ♦K
 			want:   uint8(13),
 		},
 	}

--- a/cards/readable_card.go
+++ b/cards/readable_card.go
@@ -2,6 +2,7 @@ package cards
 
 import (
 	"fmt"
+	"github.com/freecellsolver/consts"
 	"strconv"
 )
 
@@ -56,5 +57,5 @@ func (rCard ReadableCard) ToCard() (Card, error) {
 		}
 	}
 
-	return Card{suitCode<<5 + uint8(numCode)}, nil
+	return Card{suitCode<<consts.SS + uint8(numCode)}, nil
 }

--- a/cards/readable_card_test.go
+++ b/cards/readable_card_test.go
@@ -151,37 +151,37 @@ func TestReadableCard_ToCard(t *testing.T) {
 		{
 			name:    "ToCard ♥5",
 			fields:  fields{"♥", "5"},
-			want:    Card{uint8(37)},
+			want:    Card{uint8(21)},
 			wantErr: false,
 		},
 		{
 			name:    "ToCard H5",
 			fields:  fields{"H", "5"},
-			want:    Card{uint8(37)},
+			want:    Card{uint8(21)},
 			wantErr: false,
 		},
 		{
 			name:    "ToCard ♣10",
 			fields:  fields{"♣", "10"},
-			want:    Card{uint8(74)},
+			want:    Card{uint8(42)},
 			wantErr: false,
 		},
 		{
 			name:    "ToCard C10",
 			fields:  fields{"C", "10"},
-			want:    Card{uint8(74)},
+			want:    Card{uint8(42)},
 			wantErr: false,
 		},
 		{
 			name:    "ToCard ♦K",
 			fields:  fields{"♦", "K"},
-			want:    Card{uint8(109)},
+			want:    Card{uint8(61)},
 			wantErr: false,
 		},
 		{
 			name:    "ToCard DK",
 			fields:  fields{"D", "K"},
-			want:    Card{uint8(109)},
+			want:    Card{uint8(61)},
 			wantErr: false,
 		},
 		{

--- a/cells/field_cell_test.go
+++ b/cells/field_cell_test.go
@@ -44,7 +44,7 @@ func TestFieldCell_CanPlace(t *testing.T) {
 			name: "Filled stack: different color OK",
 			fields: fields{
 				CardStack: []cards.Card{
-					{uint8(34)},
+					{uint8(18)},
 				},
 			},
 			args: args{
@@ -56,7 +56,7 @@ func TestFieldCell_CanPlace(t *testing.T) {
 			name: "Filled stack: different color incorrect order NG",
 			fields: fields{
 				CardStack: []cards.Card{
-					{uint8(35)},
+					{uint8(19)},
 				},
 			},
 			args: args{

--- a/cells/home_cell_test.go
+++ b/cells/home_cell_test.go
@@ -29,7 +29,7 @@ func TestHomeCell_CanPlace(t *testing.T) {
 				},
 				SuitCode: uint8(0),
 			},
-			args: args{card: cards.Card{Code: uint8(33)}},
+			args: args{card: cards.Card{Code: uint8(17)}},
 			want: false,
 		},
 		{

--- a/consts/cnst.go
+++ b/consts/cnst.go
@@ -1,0 +1,4 @@
+package consts
+
+// SS suit shift
+const SS = uint8(4)


### PR DESCRIPTION
The number of digits required to separate suits and numbers was incorrect(🙅5, 🙆4), and has been corrected to the minimum necessary bit shift.